### PR TITLE
Fix edit command erasing existing remark when any field is edited

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -129,7 +129,8 @@ public class EditCommand extends Command {
         boolean updatedInterviewed = personToEdit.isInterviewed();
         Remark updatedRemark = personToEdit.getRemark();
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedInterviewed, updatedRemark);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedInterviewed,
+                updatedRemark);
     }
 
     @Override


### PR DESCRIPTION
Fix #185 